### PR TITLE
Edit pluralize/singularize field name

### DIFF
--- a/lib/generators/rondo_form/templates/nested_rondo_controller.js
+++ b/lib/generators/rondo_form/templates/nested_rondo_controller.js
@@ -7,8 +7,7 @@ export default class extends Controller {
   addField(e) {
     e.preventDefault();
 
-    let assoc = e.target.dataset.association;
-    let newField = this.buildNewAssociation(assoc);
+    const newField = this.buildNewAssociation(e);
     this.fieldContainTarget.insertAdjacentHTML("beforeend", newField);
   }
 
@@ -24,16 +23,19 @@ export default class extends Controller {
     }
   }
 
-  buildNewAssociation(assoc) {
-    let content  = this.templateTarget.innerHTML;
-    let regexpBraced = new RegExp('\\[new_' + assoc + '\\]', 'g');
+  buildNewAssociation(element) {
+    const assoc = element.target.dataset.association;
+    const assocs = element.target.dataset.associations;
+    const content  = this.templateTarget.innerHTML;
+    
+    let regexpBraced = new RegExp('\\[new_' + assoc + '\\](.*?\\s)', 'g');
     let newId  = new Date().getTime();
-    let newContent = content.replace(regexpBraced, '[' + newId + ']');
+    let newContent = content.replace(regexpBraced, '[' + newId + ']$1');
 
     if (newContent == content) {
       // assoc can be singular or plural 
-      regexpBraced = new RegExp('\\[new_' + assoc + 's\\]', 'g');
-      newContent = content.replace(regexpBraced, '[' + newId + ']');
+      regexpBraced = new RegExp('\\[new_' + assocs + '\\](.*?\\s)', 'g');
+      newContent = content.replace(regexpBraced, '[' + newId + ']$1');
     }
     return newContent;
   }

--- a/lib/rondo_form/view_helpers.rb
+++ b/lib/rondo_form/view_helpers.rb
@@ -48,6 +48,7 @@ module RondoForm
 
         html_options[:class] = [html_options[:class], "add_fields"].compact.join(' ')
         html_options[:'data-association'] = association.to_s.singularize
+        html_options[:'data-associations'] = association.to_s.pluralize
         html_options[:'data-action'] = "click->nested-rondo#addField"
 
         new_object = f.object.class.reflect_on_association(association).klass.new


### PR DESCRIPTION
Fix the bug is mentioned in #6, #2 .
Can not replace by regex due to wrong plural/singular of field's name.