### PR TITLE
Support passing locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 1.0.0
 ## Breaking Changes
-- Add `render_options` as parameter to `link_to_add_association` #10
-- Rename `partial_name` to `partial` to match Rails helper #10
+- Add `render_options` as parameter to `link_to_add_association` [#10](https://github.com/hungle00/rondo_form/pull/10)
+- Rename `partial_name` to `partial` to match Rails helper [#10](https://github.com/hungle00/rondo_form/pull/10)
 
 ## All Changes
-- Add documentation of the view helpers to the README #10
+- Add documentation of the view helpers to the README [#10](https://github.com/hungle00/rondo_form/pull/10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 1.0.0
+## Breaking Changes
+- Add `render_options` as parameter to `link_to_add_association` #10
+- Rename `partial_name` to `partial` to match Rails helper #10
+
+## All Changes
+- Add documentation of the view helpers to the README #10

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ can be passed as `nil` or and empty hash `{}`.
 provide the options that are desired when rendering your association fields. If no special requirements are needed,
 can be passed as `nil` or and empty hash `{}`.
 
-### `link_to_remove_association(name, f, html_options, &block)`
+### `link_to_remove_association(name, form_builder, html_options, &block)`
 
 ### Signatures
 ```ruby

--- a/README.md
+++ b/README.md
@@ -34,6 +34,45 @@ class Project < ApplicationRecord
 end
 ```
 
+## View helpers
+
+### `link_to_add_association(name, form_builder, render_options, html_options, &block)`
+
+### Signatures
+```ruby
+link_to_add_association(name, form_builder, render_options, html_options)
+# Link text is passed in as name
+
+link_to_add_association(form_builder, render_options, html_options, &block)
+# Link text is passed in as a block
+```
+
+### Options
+- `render_options: hash containing options for Rails' render helper` - This is passed to the Rails `render` helper to
+provide the options that are desired when rendering your association fields. If no special requirements are needed,
+can be passed as `nil` or and empty hash `{}`.
+
+- `html_options: hash containing options for Rails' link_to helper` - This is passed to the Rails `link_to` helper to
+provide the options that are desired when rendering your association fields. If no special requirements are needed,
+can be passed as `nil` or and empty hash `{}`.
+
+### `link_to_remove_association(name, f, html_options, &block)`
+
+### Signatures
+```ruby
+link_to_remove_association(name, form_builder, html_options)
+# Link text is passed in as name
+
+link_to_remove_association(form_builder, html_options, &block)
+# Link text is passed in as a block
+```
+
+### Options
+
+- `html_options: hash containing options for Rails' link_to helper` - This is passed to the Rails `link_to` helper to
+provide the options that are desired when rendering your association fields. If no special requirements are needed,
+can be passed as `nil` or and empty hash `{}`.
+
 ### Sample with SimpleForm
 
 The RondoForm gem adds two helper functions: `link_to_add_association` and `link_to_remove_association`.

--- a/lib/rondo_form/version.rb
+++ b/lib/rondo_form/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RondoForm
-  VERSION = "0.2.6"
+  VERSION = "1.0.0"
 end

--- a/lib/rondo_form/view_helpers.rb
+++ b/lib/rondo_form/view_helpers.rb
@@ -31,12 +31,14 @@ module RondoForm
 
     # shows a link that will allow to dynamically add a new associated object.
     #
-    # - *name* :            the text to show in the link
-    # - *f* :               the form this should come in
-    # - *association* :     the associated objects, e.g. :tasks, this should be the name of the <tt>has_many</tt> relation.
-    # - *render_options*:   options to be passed to <tt>render</tt>
+    # - *name* :               the text to show in the link
+    # - *f* :                  the form this should come in
+    # - *association* :        the associated objects, e.g. :tasks, this should be the name of the <tt>has_many</tt> relation.
+    # - *render_options*:      options to be passed to <tt>render</tt>
+    #   - partial: 'file_name'
+    #   - locals: { hash_of: 'local variables for rendered partial' }
     # - *html_options*:     html options to be passed to <tt>link_to</tt> (see <tt>link_to</tt>)
-    # - *&block*:           see <tt>link_to</tt>
+    # - *&block*:              see <tt>link_to</tt>
 
     def link_to_add_association(*args, &block)
       if block_given?


### PR DESCRIPTION
Couple things to say here- I noticed in cocoon they passed locals as part of `html_options` which didn't make sense to me, since they're completely separate. As such, I broke from the "cocoon-ness" of this gem to provide this functionality in a way that made the most sense to me. I will note however that this PR introduces breaking changes, which is likely the reason cocoon did it the way they did. 

If you were to ask my opinion, I'd say to go with this implementation and merge it with a major version upgrade. 

I can refactor to implement the way cocoon did, if you're very against this format, though.

I also renamed `partial_name` to `partial` to match Rails

I will add a documentation update with usage examples once I have your decision about what implementation you'd like to go with