### PR TITLE
Update nested-rondo stimulus controller for links with blocks

### DIFF
--- a/lib/generators/rondo_form/templates/nested_rondo_controller.js
+++ b/lib/generators/rondo_form/templates/nested_rondo_controller.js
@@ -14,7 +14,7 @@ export default class extends Controller {
   removeField(e) {
     e.preventDefault();
     const wrapperField = this.hasFieldClassValue ? e.target.closest("." + this.fieldClassValue) : e.target.parentNode;
-    
+
     if(e.target.matches('.dynamic')) {
       wrapperField.remove();
     } else {
@@ -23,17 +23,23 @@ export default class extends Controller {
     }
   }
 
-  buildNewAssociation(element) {
-    const assoc = element.target.dataset.association;
-    const assocs = element.target.dataset.associations;
+  buildNewAssociation(event) {
+    let element = event.target;
+    while (element) {
+      if (element.hasAttribute('data-association') || element.hasAttribute('data-associations'))
+        break
+      element = element.parentElement;
+    }
+    const assoc = element.dataset.association;
+    const assocs = element.dataset.associations;
     const content  = this.templateTarget.innerHTML;
-    
+
     let regexpBraced = new RegExp('\\[new_' + assoc + '\\](.*?\\s)', 'g');
     let newId  = new Date().getTime();
     let newContent = content.replace(regexpBraced, '[' + newId + ']$1');
 
     if (newContent == content) {
-      // assoc can be singular or plural 
+      // assoc can be singular or plural
       regexpBraced = new RegExp('\\[new_' + assocs + '\\](.*?\\s)', 'g');
       newContent = content.replace(regexpBraced, '[' + newId + ']$1');
     }


### PR DESCRIPTION
Noticed the following when using the `link_to_add_association` with a block like this:
```ruby
<%= link_to_add_association @form, :photos, class: 'w-[200px] h-[200px] flex items-center justify-center' do %>
  <svg class="w-14 h-14 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14m-7 7V5"/>
  </svg>
<% end %>
```
When an inner element of the link is smaller than the containing anchor, and clicking that SVG element the nested-rondo controller uses the `event.target` of the SVG instead of the anchor, and the `dataset.association` accessors return undefined, thus the `[new_photos]` is never updated and the controller dismisses new records to be added.

This fix aims to traverse the element that was clicked until the one with the `data-association` or `data-associations` attributes are found and use that element for the rest of the method.